### PR TITLE
feat(icons): add acf partial and basic styles for icons

### DIFF
--- a/src/Icon/Fields/Partials/Icon.php
+++ b/src/Icon/Fields/Partials/Icon.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Bloom\Modules\Icon\Fields\Partials;
+
+use Illuminate\Filesystem\Filesystem;
+use Log1x\AcfComposer\Builder;
+use Log1x\AcfComposer\Partial;
+
+class Icon extends Partial
+{
+    /**
+     * The partial field group.
+     */
+    public function fields(): Builder
+    {
+        $icon = Builder::make('icon');
+
+        $icon
+            ->addSelect('icon', [
+                'label' => 'Icon',
+                'instructions' => 'Select an icon',
+                'choices' => $this->getIcons(),
+                'allow_null' => 0,
+                'ui' => 1,
+                'ajax' => 1,
+            ]);
+
+        return $icon;
+    }
+
+    protected function getIcons(): array
+    {
+        $filesystem = new Filesystem();
+        $files = $filesystem->allFiles(get_template_directory() . '/resources/images/icons');
+
+        if (!$files) {
+            return [];
+        }
+
+        $icons = [];
+
+        foreach ($files as $file) {
+            $iconValue = $file->getFilenameWithoutExtension();
+            $iconLabel = ucwords($file->getFilenameWithoutExtension());
+            $icons[$iconValue] = $iconLabel;
+        }
+
+        return $icons ?? [];
+    }
+}

--- a/src/Icon/resources/styles/icons.scss
+++ b/src/Icon/resources/styles/icons.scss
@@ -1,0 +1,17 @@
+.c-icon {
+  &--up {
+    tranform: rotate(0);
+  }
+
+  &--right {
+    transform: rotate(45deg);
+  }
+
+  &--down {
+    transform: rotate(180deg);
+  }
+
+  &--left {
+    transform: rotate(270deg);
+  }
+}


### PR DESCRIPTION
This module adds an ACF partial which can be added to any ACF block. It displays a select list populated by all files in the `resources/images/icons` directory:

<img width="272" alt="image" src="https://github.com/hex-digital/bloom-modules/assets/84968815/6e81553b-d9a0-427c-9700-c4d531dc9d9c">

<img width="380" alt="image" src="https://github.com/hex-digital/bloom-modules/assets/84968815/d87cc917-d23f-44c5-ab70-2d0475dd3629">


```
<x-icon-hex />
<x-icon-hex class="c-icon--right" />
<x-icon-hex class="c-icon--down" />
<x-icon-hex class="c-icon--left"/>
```
or 

```
@svg('hex')
@svg('hex', 'c-icon--right)
@svg('hex', 'c-icon--down)
@svg('hex', 'c-icon--left)
```

<img width="272" alt="image" src="https://github.com/hex-digital/bloom-modules/assets/84968815/ff9e363f-9d9d-4710-9f6e-34442f7ef144">
